### PR TITLE
Set a supplied password when an AP demands a change at login

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ Use `-ask-pass` rather than `-pass`: `cmd.exe` eats `^` as an escape character,
 every shell claims a different set, and an argument is visible in the process
 list. Run `crossbreeder-plus -h` for the rest.
 
+A factory-default AP demands a password change before it will do anything else.
+Give it one with the **New password** field, or `-new-pass` / `-ask-new-pass`,
+and it is set as part of the same run. Leave it empty and those APs are reported
+as needing one and skipped, rather than being guessed at.
+
 ## What it does
 
 - **Pings first.** Most addresses on a site list are dead, and each one costs a

--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -42,6 +42,21 @@ localhost. Everything it can do is also available as flags: run it with `-h`.
   rebooting and one that comes back on a new version is reported as upgraded.
 - **CSV and JSON output**, with a row for every address including the silent
   ones.
+- **Onboards factory-default APs.** An AP that demands a password change at
+  first login has the password you supply set on it, and the run carries on to
+  whatever else you asked for. Without one, it is reported as needing a password
+  rather than being guessed at.
+
+## Fixed
+
+- **A forced password change no longer kills the run**
+  ([#5](https://github.com/andreacoppini/crossbreeder/issues/5)). The CLI login
+  matched the password prompt as a substring, so *"Please enter new password:"*
+  was answered with the password the tool had just logged in with. The AP
+  refused it, and the session never reached a prompt — so nothing after it ran.
+  Prompts are now matched at the end of the line and case-insensitively, which
+  also stops a status line like *"Password changed."* being mistaken for a
+  prompt and the password being sent as a CLI command.
 
 ## Known limits
 

--- a/engine/ap/expect.go
+++ b/engine/ap/expect.go
@@ -80,10 +80,15 @@ type pat struct {
 	// distinguishes a prompt the device is waiting at from the same characters
 	// appearing in a banner or in echoed output.
 	atEnd bool
+	// fold matches without regard to case, for prompts whose capitalisation
+	// differs between firmware builds ("New Password:" against "new password:").
+	fold bool
 }
 
-func anywhere(s string) pat { return pat{text: s} }
-func atEnd(s string) pat    { return pat{text: s, atEnd: true} }
+func anywhere(s string) pat     { return pat{text: s} }
+func atEnd(s string) pat        { return pat{text: s, atEnd: true} }
+func anywhereFold(s string) pat { return pat{text: s, fold: true} }
+func atEndFold(s string) pat    { return pat{text: s, atEnd: true, fold: true} }
 
 // Collect keeps reading for up to d and returns whatever arrived. It is for
 // watching a long-running operation that prints progress without ever coming
@@ -168,7 +173,11 @@ func (e *expecter) scan(want []pat) (int, string, bool) {
 		if w.atEnd {
 			continue
 		}
-		if at := strings.Index(s, w.text); at >= 0 && (bestAt < 0 || at < bestAt) {
+		at := strings.Index(s, w.text)
+		if w.fold {
+			at = indexFold(s, w.text)
+		}
+		if at >= 0 && (bestAt < 0 || at < bestAt) {
 			bestIdx, bestAt = i, at
 		}
 	}
@@ -182,7 +191,12 @@ func (e *expecter) scan(want []pat) (int, string, bool) {
 		if !w.atEnd {
 			continue
 		}
-		if strings.HasSuffix(tail, strings.TrimRight(w.text, " ")) {
+		text := strings.TrimRight(w.text, " ")
+		hit := strings.HasSuffix(tail, text)
+		if w.fold {
+			hit = hasSuffixFold(tail, text)
+		}
+		if hit {
 			if bestIdx < 0 || len(w.text) > len(want[bestIdx].text) {
 				bestIdx = i
 			}
@@ -215,4 +229,45 @@ func (e *expecter) drain() string {
 	s := e.buf.String()
 	e.buf.Reset()
 	return s
+}
+
+// indexFold is strings.Index with ASCII case folding. It compares byte by byte
+// rather than lowercasing a copy, so the index it returns is an offset into s
+// itself — which scan relies on to consume exactly the matched text.
+func indexFold(s, sub string) int {
+	if sub == "" {
+		return 0
+	}
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if equalFold(s[i:i+len(sub)], sub) {
+			return i
+		}
+	}
+	return -1
+}
+
+func hasSuffixFold(s, suffix string) bool {
+	return len(s) >= len(suffix) && equalFold(s[len(s)-len(suffix):], suffix)
+}
+
+// equalFold compares two equal-length strings with ASCII case folding. The AP
+// CLI is ASCII, so this deliberately does not do Unicode folding, which could
+// change byte length and so break the offsets indexFold hands back.
+func equalFold(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		if lowerASCII(a[i]) != lowerASCII(b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func lowerASCII(c byte) byte {
+	if c >= 'A' && c <= 'Z' {
+		return c + 'a' - 'A'
+	}
+	return c
 }

--- a/engine/ap/pwchange_test.go
+++ b/engine/ap/pwchange_test.go
@@ -1,0 +1,352 @@
+package ap
+
+import (
+	"bufio"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// forcedChangeAP is a factory-default AP: it accepts the default credentials
+// and then refuses to go any further until the password is changed, rejecting
+// any new password equal to the old one — which is what a real Ruckus AP does
+// on first login.
+type forcedChangeAP struct {
+	ln net.Listener
+	// relogin models the builds that throw you back to the login prompt after
+	// the change, where only the new password is accepted.
+	relogin bool
+
+	mu       sync.Mutex
+	offered  []string // every value sent at a "new password" prompt
+	loggedIn []string // every password sent at an ordinary login prompt
+	reached  bool     // did the client ever get to the CLI prompt
+}
+
+func newForcedChangeAP(t *testing.T) *forcedChangeAP {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := &forcedChangeAP{ln: ln}
+	_, priv, _ := ed25519.GenerateKey(rand.Reader)
+	signer, _ := ssh.NewSignerFromKey(priv)
+	conf := &ssh.ServerConfig{
+		PasswordCallback: func(ssh.ConnMetadata, []byte) (*ssh.Permissions, error) { return nil, nil },
+	}
+	conf.AddHostKey(signer)
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go f.serve(c, conf)
+		}
+	}()
+	t.Cleanup(func() { _ = ln.Close() })
+	return f
+}
+
+func (f *forcedChangeAP) addr() (string, string) {
+	h, p, _ := net.SplitHostPort(f.ln.Addr().String())
+	return h, p
+}
+
+func (f *forcedChangeAP) serve(c net.Conn, conf *ssh.ServerConfig) {
+	sc, chans, reqs, err := ssh.NewServerConn(c, conf)
+	if err != nil {
+		return
+	}
+	defer sc.Close()
+	go ssh.DiscardRequests(reqs)
+	for nc := range chans {
+		if nc.ChannelType() != "session" {
+			_ = nc.Reject(ssh.UnknownChannelType, "no")
+			continue
+		}
+		ch, creqs, err := nc.Accept()
+		if err != nil {
+			return
+		}
+		go func() {
+			for r := range creqs {
+				if r.WantReply {
+					_ = r.Reply(r.Type == "pty-req" || r.Type == "shell", nil)
+				}
+			}
+		}()
+		f.cli(ch)
+		_ = ch.Close()
+	}
+}
+
+const (
+	defaultPass    = "sp-admin"
+	newPassForTest = "Str0ngNewPass!"
+)
+
+func (f *forcedChangeAP) cli(ch ssh.Channel) {
+	in := bufio.NewReader(ch)
+	say := func(s string) { _, _ = ch.Write([]byte(s)) }
+	line := func() (string, bool) {
+		l, err := in.ReadString('\n')
+		if err != nil {
+			return "", false
+		}
+		return strings.TrimRight(l, "\r\n"), true
+	}
+
+	say("\r\nPlease login: ")
+	if _, ok := line(); !ok {
+		return
+	}
+	say("password : ")
+	pw, ok := line()
+	if !ok {
+		return
+	}
+	f.mu.Lock()
+	f.loggedIn = append(f.loggedIn, pw)
+	f.mu.Unlock()
+
+	// Accepted — but the AP now insists on a new password before anything else.
+	say("\r\n** The default password must be changed before continuing **\r\n")
+	for {
+		say("Please enter new password : ")
+		np, ok := line()
+		if !ok {
+			return
+		}
+		f.mu.Lock()
+		f.offered = append(f.offered, np)
+		f.mu.Unlock()
+
+		if np == defaultPass || np == "" {
+			say("\r\nPassword can not be the same as the default password.\r\n")
+			continue
+		}
+		say("Please confirm new password : ")
+		cp, ok := line()
+		if !ok {
+			return
+		}
+		if cp != np {
+			say("\r\nPasswords do not match.\r\n")
+			continue
+		}
+		break
+	}
+
+	if f.relogin {
+		// Log the session out and insist on the new password this time.
+		say("\r\nPassword changed. Please log in again.\r\n")
+		for {
+			say("\r\nPlease login: ")
+			if _, ok := line(); !ok {
+				return
+			}
+			say("password : ")
+			pw, ok := line()
+			if !ok {
+				return
+			}
+			f.mu.Lock()
+			f.loggedIn = append(f.loggedIn, pw)
+			f.mu.Unlock()
+			if pw == newPassForTest {
+				break
+			}
+			say("\r\nLogin incorrect\r\n")
+		}
+	}
+
+	f.mu.Lock()
+	f.reached = true
+	f.mu.Unlock()
+	say("\r\nPassword changed.\r\nrkscli: ")
+	for {
+		cmd, ok := line()
+		if !ok {
+			return
+		}
+		if cmd == "get version" {
+			say("Version: 110.0.0.0.1347\r\n")
+		}
+		say("rkscli: ")
+	}
+}
+
+// Issue #5: on an AP that demands a password change at first login, the tool
+// used to answer the "new password" prompt with the password it had just
+// logged in with. The AP refuses that, and the run died without ever reaching
+// a prompt.
+func TestForcedPasswordChangeSetsTheSuppliedPassword(t *testing.T) {
+	f := newForcedChangeAP(t)
+	host, port := f.addr()
+
+	cfg := testConfig()
+	cfg.Port = port
+	cfg.Credentials = []Credentials{{User: "super", Password: defaultPass}}
+	cfg.NewPassword = newPassForTest
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	r := Run(ctx, host, cfg)
+
+	f.mu.Lock()
+	offered, reached := append([]string(nil), f.offered...), f.reached
+	f.mu.Unlock()
+
+	if r.Error != "" {
+		t.Fatalf("Run failed: %s", r.Error)
+	}
+	if !reached {
+		t.Fatal("never reached the CLI prompt")
+	}
+	for _, v := range offered {
+		if v == defaultPass {
+			t.Fatalf("sent the current password as the new one; offered = %q", offered)
+		}
+	}
+	if len(offered) != 1 || offered[0] != newPassForTest {
+		t.Errorf("offered = %q, want exactly one %q", offered, newPassForTest)
+	}
+	if r.Note != "password changed" {
+		t.Errorf("Note = %q, want %q", r.Note, "password changed")
+	}
+	if r.Firmware != "110.0.0.0.1347" {
+		t.Errorf("Firmware = %q; the run did not carry on past the change", r.Firmware)
+	}
+}
+
+// With no new password to set, the AP is reported and skipped. It must not
+// guess, and it must not sit there burning the deadline.
+func TestForcedPasswordChangeWithoutOneIsReported(t *testing.T) {
+	f := newForcedChangeAP(t)
+	host, port := f.addr()
+
+	cfg := testConfig()
+	cfg.Port = port
+	cfg.Credentials = []Credentials{{User: "super", Password: defaultPass}}
+	cfg.NewPassword = ""
+
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	r := Run(ctx, host, cfg)
+	elapsed := time.Since(start)
+
+	f.mu.Lock()
+	offered := append([]string(nil), f.offered...)
+	f.mu.Unlock()
+
+	if len(offered) != 0 {
+		t.Errorf("sent %q at the new-password prompt; it should send nothing", offered)
+	}
+	if r.Status != "Needs Password" {
+		t.Errorf("Status = %q, want %q", r.Status, "Needs Password")
+	}
+	if !strings.Contains(r.Error, "requires a password change") {
+		t.Errorf("Error = %q, want it to say a password change is required", r.Error)
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("took %v; it waited out a timeout instead of reporting straight away", elapsed)
+	}
+}
+
+// Some builds throw the session back to the login prompt after the change. The
+// old password is dead by then, so the new one has to be used.
+func TestReloginAfterChangeUsesTheNewPassword(t *testing.T) {
+	f := newForcedChangeAP(t)
+	f.relogin = true
+	host, port := f.addr()
+
+	cfg := testConfig()
+	cfg.Port = port
+	cfg.Credentials = []Credentials{{User: "super", Password: defaultPass}}
+	cfg.NewPassword = newPassForTest
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	r := Run(ctx, host, cfg)
+
+	f.mu.Lock()
+	loggedIn, reached := append([]string(nil), f.loggedIn...), f.reached
+	f.mu.Unlock()
+
+	if r.Error != "" {
+		t.Fatalf("Run failed: %s", r.Error)
+	}
+	if !reached {
+		t.Fatal("never reached the CLI prompt after the re-login")
+	}
+	if len(loggedIn) < 2 || loggedIn[len(loggedIn)-1] != newPassForTest {
+		t.Errorf("passwords sent at login = %q, want the last to be the new one", loggedIn)
+	}
+}
+
+// "Password changed." contains the word the login state machine watches for.
+// Treating it as a prompt would send the password as a CLI command, putting it
+// into the AP's command history.
+func TestStatusLineIsNotMistakenForAPasswordPrompt(t *testing.T) {
+	e := newExpecter(nil, strings.NewReader("\r\nPassword changed.\r\nrkscli: "), time.Second)
+	i, _, err := e.ExpectPats(
+		atEndFold("password:"), atEndFold("password :"), atEnd("rkscli: "),
+	)
+	if err != nil {
+		t.Fatalf("expect: %v", err)
+	}
+	if i != 2 {
+		t.Errorf("matched pattern %d; the word inside \"Password changed.\" was treated as a prompt", i)
+	}
+}
+
+// The prompts differ only by prefix, so the longest end-anchored match has to
+// win or a confirmation gets answered as if it were the first prompt.
+func TestConfirmPromptBeatsTheNewPasswordPrompt(t *testing.T) {
+	cases := []struct {
+		text string
+		want int
+	}{
+		{"\r\nPlease enter new password : ", 1},
+		{"\r\nNew Password: ", 1},
+		{"\r\nPlease confirm new password : ", 2},
+		{"\r\nConfirm New Password: ", 2},
+		{"\r\nRe-enter new password: ", 2},
+		{"\r\npassword : ", 0},
+		{"\r\nPassword: ", 0},
+	}
+	for _, c := range cases {
+		e := newExpecter(nil, strings.NewReader(c.text), time.Second)
+		i, _, err := e.ExpectPats(
+			atEndFold("password:"),                                  // 0
+			atEndFold("new password:"), atEndFold("new password :"), // 1 (and 2 below)
+			atEndFold("confirm new password:"), atEndFold("confirm new password :"),
+			atEndFold("re-enter new password:"),
+			atEndFold("password :"),
+		)
+		if err != nil {
+			t.Errorf("%q: %v", c.text, err)
+			continue
+		}
+		got := 0
+		switch {
+		case i == 1 || i == 2:
+			got = 1
+		case i >= 3 && i <= 5:
+			got = 2
+		}
+		if got != c.want {
+			t.Errorf("%q matched pattern %d (class %d), want class %d", c.text, i, got, c.want)
+		}
+	}
+}

--- a/engine/ap/session.go
+++ b/engine/ap/session.go
@@ -6,6 +6,7 @@ package ap
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -72,6 +73,11 @@ type Config struct {
 	// LegacyAlgorithms re-enables the SHA-1 / CBC primitives that pre-2015
 	// ZoneFlex firmware negotiates and modern SSH stacks refuse by default.
 	LegacyAlgorithms bool
+	// NewPassword is what to answer with when an AP demands a password change
+	// at first login, which a factory-default AP does before it will do
+	// anything else. Left empty, such an AP is reported and skipped rather than
+	// guessed at: the tool never invents a credential for a device.
+	NewPassword string
 }
 
 // Result is one row of the output table.
@@ -141,6 +147,10 @@ var unleashed = dialect{
 	},
 }
 
+// ErrPasswordChangeRequired means the AP refused to go any further until its
+// password was changed, and no replacement was supplied to set.
+var ErrPasswordChangeRequired = errors.New("AP requires a password change; supply a new password to set one")
+
 // Run drives one AP to completion. It never touches shared state, so N of these
 // may be in flight at once.
 // The return value is named so the deferred timing actually lands on it: a
@@ -209,10 +219,16 @@ func run(ctx context.Context, host string, cfg Config, r *Result) error {
 	e := newExpecter(stdin, stdout, cfg.DialogTimeout)
 	defer func() { r.Transcript = e.Transcript() }()
 
-	d, err := login(e, cfg.Credentials)
+	d, changed, err := login(e, cfg.Credentials, cfg.NewPassword)
 	if err != nil {
 		r.Status = "Login Failed"
+		if errors.Is(err, ErrPasswordChangeRequired) {
+			r.Status = "Needs Password"
+		}
 		return err
+	}
+	if changed {
+		r.Note = "password changed"
 	}
 	r.Kind = d.kind
 
@@ -370,61 +386,123 @@ func dial(ctx context.Context, host string, cfg Config) (*ssh.Client, error) {
 // SSH transport login was the only one, and some answer a rejected password
 // with a fresh banner; guessing wrong used to cost a full timeout and then lose
 // the prompt that had already arrived.
-func login(e *expecter, creds []Credentials) (dialect, error) {
+func login(e *expecter, creds []Credentials, newPass string) (dialect, bool, error) {
 	if len(creds) == 0 {
-		return dialect{}, fmt.Errorf("no credentials supplied")
+		return dialect{}, false, fmt.Errorf("no credentials supplied")
 	}
 
 	const (
-		wantLogin = iota
-		wantUser
-		wantPassword
-		wantIncorrect
-		wantDenied
-		promptZF
-		promptULEnable
-		promptUL
+		actLogin = iota
+		actUser
+		actPassword
+		actNewPassword
+		actConfirmPassword
+		actRejected
+		actIncorrect
+		actDenied
+		actPromptZF
+		actPromptUL
 	)
-	pats := []pat{
-		anywhere("ogin:"),
-		anywhere("sername:"),
-		anywhere("assword"),
-		anywhere("Login incorrect"),
-		anywhere("Permission denied"),
-		atEnd("rkscli: "),
-		atEnd("(ap-mode)# "),
-		atEnd("> "),
+
+	var (
+		pats []pat
+		acts []int
+	)
+	add := func(act int, ps ...pat) {
+		for _, x := range ps {
+			pats = append(pats, x)
+			acts = append(acts, act)
+		}
 	}
+
+	// The prompts are end-anchored: these same words appear inside banners and
+	// status lines ("Password changed."), and answering one of those would send
+	// the password as a command, putting it in the AP's history. Anchoring also
+	// buys the disambiguation for free, because scan resolves end-anchored
+	// patterns longest-first: "confirm new password:" beats "new password:",
+	// which beats "password:". Getting that wrong is the bug this fixes.
+	add(actLogin, atEndFold("login:"))
+	add(actUser, atEndFold("username:"))
+	add(actPassword, atEndFold("password:"), atEndFold("password :"))
+	add(actNewPassword,
+		atEndFold("new password:"), atEndFold("new password :"),
+		atEndFold("change your password:"), atEndFold("change your password :"),
+	)
+	add(actConfirmPassword,
+		atEndFold("confirm new password:"), atEndFold("confirm new password :"),
+		atEndFold("confirm password:"), atEndFold("confirm password :"),
+		atEndFold("re-enter new password:"), atEndFold("re-enter new password :"),
+		atEndFold("reenter new password:"), atEndFold("reenter new password :"),
+		atEndFold("retype new password:"), atEndFold("retype new password :"),
+		atEndFold("verify new password:"), atEndFold("verify new password :"),
+		atEndFold("confirm:"), atEndFold("confirm :"),
+	)
+	// Messages, by contrast, stay free: they have to win against a prompt that
+	// arrives after them, which earliest-position matching gives us.
+	add(actRejected,
+		anywhereFold("can not be the same"), anywhereFold("cannot be the same"),
+		anywhereFold("must be different"), anywhereFold("do not match"),
+		anywhereFold("does not match"), anywhereFold("too short"),
+		anywhereFold("password is invalid"), anywhereFold("not strong enough"),
+	)
+	add(actIncorrect, anywhere("Login incorrect"))
+	add(actDenied, anywhere("Permission denied"))
+	add(actPromptZF, atEnd("rkscli: "))
+	add(actPromptUL, atEnd("(ap-mode)# "), atEnd("> "))
 
 	cred := 0
+	changed := false
 	// Bounded so a device that loops its banner cannot spin here forever.
-	for step := 0; step < 4*len(creds)+8; step++ {
-		i, _, err := e.ExpectPats(pats...)
+	for step := 0; step < 4*len(creds)+12; step++ {
+		i, out, err := e.ExpectPats(pats...)
 		if err != nil {
-			return dialect{}, fmt.Errorf("%w; last seen: %s", err, tail(e.Pending(), 160))
+			return dialect{}, changed, fmt.Errorf("%w; last seen: %s", err, tail(e.Pending(), 160))
 		}
 
-		switch i {
-		case wantLogin, wantUser:
+		switch acts[i] {
+		case actLogin, actUser:
 			if err := e.Send(creds[cred].User); err != nil {
-				return dialect{}, err
+				return dialect{}, changed, err
 			}
-		case wantPassword:
-			if err := e.Send(creds[cred].Password); err != nil {
-				return dialect{}, err
+		case actPassword:
+			// After a change the AP may drop the session back to a login, and
+			// the old password will no longer be accepted.
+			pw := creds[cred].Password
+			if changed {
+				pw = newPass
 			}
-		case wantIncorrect, wantDenied:
+			if err := e.Send(pw); err != nil {
+				return dialect{}, changed, err
+			}
+		case actNewPassword, actConfirmPassword:
+			if newPass == "" {
+				return dialect{}, false, ErrPasswordChangeRequired
+			}
+			if err := e.Send(newPass); err != nil {
+				return dialect{}, changed, err
+			}
+			// Only the confirmation tells us the AP accepted it; a rejection
+			// arrives as its own message and is handled below.
+			if acts[i] == actConfirmPassword {
+				changed = true
+			}
+		case actRejected:
+			return dialect{}, false, fmt.Errorf("AP rejected the new password: %s", tail(out, 120))
+		case actIncorrect, actDenied:
+			if changed {
+				return dialect{}, changed, fmt.Errorf("AP rejected the new password at re-login")
+			}
 			cred++
 			if cred >= len(creds) {
-				return dialect{}, fmt.Errorf("AP rejected %s", credSummary(creds))
+				return dialect{}, false, fmt.Errorf("AP rejected %s", credSummary(creds))
 			}
-		case promptZF:
-			return zoneFlex, nil
-		case promptULEnable, promptUL:
-			return unleashed, nil
+		case actPromptZF:
+			return zoneFlex, changed, nil
+		case actPromptUL:
+			return unleashed, changed, nil
 		}
 	}
-	return dialect{}, fmt.Errorf("could not reach a CLI prompt; last seen: %s", tail(e.Pending(), 160))
+	return dialect{}, changed, fmt.Errorf("could not reach a CLI prompt; last seen: %s", tail(e.Pending(), 160))
 }
 
 // fwSummary reduces the AP's answer to "fw update" to the part worth carrying

--- a/engine/flags.go
+++ b/engine/flags.go
@@ -13,6 +13,9 @@ func parseFlags() options {
 	flag.StringVar(&o.pass, "pass", "", "AP password")
 	flag.BoolVar(&o.askPass, "ask-pass", false, "prompt for the AP password instead of passing it on the command line")
 	flag.StringVar(&o.passEnv, "pass-env", "", "read the AP password from this environment variable")
+	flag.StringVar(&o.newPass, "new-pass", "", "password to set when an AP demands a change at first login")
+	flag.BoolVar(&o.askNewPass, "ask-new-pass", false, "prompt for the new password instead of passing it on the command line")
+	flag.StringVar(&o.newPassEnv, "new-pass-env", "", "read the new password from this environment variable")
 	flag.BoolVar(&o.alsoDefault, "default", false, "also try the factory-default super/sp-admin login")
 	flag.IntVar(&o.concurrency, "c", 25, "how many APs to work at once")
 

--- a/engine/job.go
+++ b/engine/job.go
@@ -68,7 +68,7 @@ type JobResult struct {
 
 // buildConfig turns the flag/form options into an engine config, and returns
 // any notes the operator should see about choices made on their behalf.
-func buildConfig(opt options, password string) (ap.Config, []string, error) {
+func buildConfig(opt options, password, newPassword string) (ap.Config, []string, error) {
 	var notes []string
 
 	// A password with no username used to be discarded in silence, and the run
@@ -110,6 +110,7 @@ func buildConfig(opt options, password string) (ap.Config, []string, error) {
 			Proto: opt.fwProto, Host: opt.fwHost, Port: opt.fwPort,
 			User: opt.fwUser, Password: opt.fwPass, Filename: opt.fwFile,
 		},
+		NewPassword:      newPassword,
 		FirmwareWait:     opt.fwWait,
 		Port:             opt.sshPort,
 		ConnectTimeout:   opt.timeout,

--- a/engine/job_test.go
+++ b/engine/job_test.go
@@ -35,7 +35,7 @@ func TestCredentialSummaryFlagsAnEmptyPassword(t *testing.T) {
 // A password with no username used to be dropped in silence, and the run then
 // tried the factory defaults and blamed the AP.
 func TestPasswordWithoutUsernameIsRefused(t *testing.T) {
-	_, _, err := buildConfig(options{}, "J^60*k{PH%mp1G5e")
+	_, _, err := buildConfig(options{}, "J^60*k{PH%mp1G5e", "")
 	if err == nil {
 		t.Fatal("expected an error")
 	}
@@ -45,7 +45,7 @@ func TestPasswordWithoutUsernameIsRefused(t *testing.T) {
 }
 
 func TestNoCredentialsFallsBackToFactoryDefaults(t *testing.T) {
-	cfg, _, err := buildConfig(options{}, "")
+	cfg, _, err := buildConfig(options{}, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func TestNoCredentialsFallsBackToFactoryDefaults(t *testing.T) {
 }
 
 func TestAlsoDefaultAppendsTheFactoryPair(t *testing.T) {
-	cfg, _, err := buildConfig(options{user: "admin", alsoDefault: true}, "pw")
+	cfg, _, err := buildConfig(options{user: "admin", alsoDefault: true}, "pw", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/engine/main.go
+++ b/engine/main.go
@@ -27,7 +27,7 @@ import (
 	"github.com/andreacoppini/crossbreeder/engine/ap"
 )
 
-var version = "1.0.0"
+var version = "1.0.1"
 
 type options struct {
 	csvPath     string
@@ -36,6 +36,9 @@ type options struct {
 	pass        string
 	askPass     bool
 	passEnv     string
+	newPass     string
+	newPassEnv  string
+	askNewPass  bool
 	alsoDefault bool
 	concurrency int
 
@@ -125,7 +128,12 @@ func run(opt options) error {
 		return err
 	}
 
-	cfg, notes, err := buildConfig(opt, password)
+	newPassword, err := resolveNewPassword(opt)
+	if err != nil {
+		return err
+	}
+
+	cfg, notes, err := buildConfig(opt, password, newPassword)
 	if err != nil {
 		return err
 	}

--- a/engine/password.go
+++ b/engine/password.go
@@ -35,6 +35,25 @@ func resolvePassword(o options) (string, error) {
 	return o.pass, nil
 }
 
+// resolveNewPassword decides where the replacement password comes from, when
+// an AP demands a change at first login. Same reasoning as resolvePassword,
+// with one difference: it is never prompted for unasked. Setting a password on
+// every factory AP in a list is a deliberate act, so it happens only when one
+// of the three sources was named explicitly.
+func resolveNewPassword(o options) (string, error) {
+	if o.newPassEnv != "" {
+		v, ok := os.LookupEnv(o.newPassEnv)
+		if !ok {
+			return "", fmt.Errorf("-new-pass-env %s: environment variable is not set", o.newPassEnv)
+		}
+		return v, nil
+	}
+	if o.askNewPass {
+		return promptPassword("New password to set on APs that demand a change: ")
+	}
+	return o.newPass, nil
+}
+
 func promptPassword(prompt string) (string, error) {
 	fmt.Fprint(os.Stderr, prompt)
 	fd := int(os.Stdin.Fd())

--- a/engine/ui.go
+++ b/engine/ui.go
@@ -181,6 +181,7 @@ type runRequest struct {
 
 	User        string `json:"user"`
 	Pass        string `json:"pass"`
+	NewPass     string `json:"newPass"`
 	AlsoDefault bool   `json:"alsoDefault"`
 	Concurrency int    `json:"concurrency"`
 
@@ -247,7 +248,7 @@ func (u *uiServer) handleRun(w http.ResponseWriter, r *http.Request) {
 	u.mu.Unlock()
 
 	opt := u.opt.merge(req)
-	cfg, notes, err := buildConfig(opt, req.Pass)
+	cfg, notes, err := buildConfig(opt, req.Pass, req.NewPass)
 	if err != nil {
 		u.finish()
 		httpErr(w, err)

--- a/engine/web/app.js
+++ b/engine/web/app.js
@@ -43,7 +43,10 @@ function persist() {
   // The password is deliberately not in SAVE: it must not survive on disk. It
   // is held for this browser session only, so a reload mid-job does not empty
   // the field without the operator noticing.
-  try { sessionStorage.setItem('cb-pass', $('pass').value); } catch (e) { /* ignore */ }
+  try {
+    sessionStorage.setItem('cb-pass', $('pass').value);
+    sessionStorage.setItem('cb-newpass', $('newPass').value);
+  } catch (e) { /* ignore */ }
 }
 
 function restore() {
@@ -57,6 +60,8 @@ function restore() {
   try {
     const p = sessionStorage.getItem('cb-pass');
     if (p) $('pass').value = p;
+    const np = sessionStorage.getItem('cb-newpass');
+    if (np) $('newPass').value = np;
   } catch (e) { /* ignore */ }
   hostsChanged();
   actionsChanged();
@@ -130,6 +135,8 @@ for (const id of ['firmware', 'factory', 'reboot', 'command', 'watch']) {
 }
 for (const k of SAVE) $(k)?.addEventListener('change', persist);
 $('pass').addEventListener('input', persist);
+$('newPass').addEventListener('input', persist);
+$('newPass').addEventListener('input', credsChanged);
 $('user').addEventListener('input', credsChanged);
 $('pass').addEventListener('input', credsChanged);
 $('alsoDefault').addEventListener('change', credsChanged);
@@ -151,7 +158,8 @@ function credsChanged() {
   } else {
     el.className = 'hint';
     el.textContent = `Will try "${u}" (${p.length}-character password)` +
-      ($('alsoDefault').checked ? ', then super / sp-admin.' : '.');
+      ($('alsoDefault').checked ? ', then super / sp-admin.' : '.') +
+      ($('newPass').value ? ' An AP demanding a password change will be set to the new password.' : '');
   }
 }
 
@@ -553,7 +561,8 @@ function request() {
   const num = (id) => parseInt($(id).value, 10) || 0;
   return {
     hosts: hostList(),
-    user: $('user').value, pass: $('pass').value, alsoDefault: $('alsoDefault').checked,
+    user: $('user').value, pass: $('pass').value, newPass: $('newPass').value,
+    alsoDefault: $('alsoDefault').checked,
     concurrency: num('concurrency'),
     probe: $('probe').value,
     pingTimeoutMs: num('pingTimeoutMs'), pingRetries: num('pingRetries'),

--- a/engine/web/index.html
+++ b/engine/web/index.html
@@ -48,6 +48,8 @@
       <label><span>AP username</span><input type="text" id="user" autocomplete="off" spellcheck="false"></label>
       <label><span>AP password</span><input type="password" id="pass" autocomplete="off"></label>
       <label class="check"><input type="checkbox" id="alsoDefault"> Also try default (super / sp-admin)</label>
+      <label><span>New password</span><input type="password" id="newPass" autocomplete="off"></label>
+      <div class="hint">Set on an AP that demands a password change at first login. Leave blank and those APs are reported and skipped instead.</div>
       <div class="hint" id="credHint"></div>
     </div>
   </section>


### PR DESCRIPTION
Fixes #5.

## The bug

A factory-default AP refuses to do anything until its password is changed. The CLI login matched the password prompt as a substring — `anywhere("assword")` — so *"Please enter new password:"* fell into the same branch as the login prompt and was answered with the password just used to log in. The AP rejects that by definition, re-prompts, and the loop ran until the step budget was spent.

Against a fake AP that behaves the way the reporter's does, before the fix:

```
values sent at the new-password prompt = ["sp-admin" ×10]
reached CLI prompt = false
error = "could not reach a CLI prompt; last seen: ...Password can not be the same
         as the default password. Please enter new password :"
```

The `super`/`sp-admin` fallback makes this *more* likely to fire, not less — so it hits exactly the fleet you would most want to bulk-onboard.

## The fix

**Prompts are matched at the end of the line, not anywhere in it, and case-insensitively** (capitalisation varies between builds: `New Password:` against `new password:`). End-anchoring buys the disambiguation for free, because `scan` already resolves end-anchored patterns longest-first:

```
"confirm new password:"  beats  "new password:"  beats  "password:"
```

It also fixes a second problem the old matching had: a status line like `Password changed.` contains the watched substring, so it was read as a prompt and the password was sent as a CLI command — putting it in the AP's history. There is a test for that specifically.

**A new password can be supplied**, and is set and confirmed as part of the run, which then carries on to whatever else was asked for:

- **New password** field in the console (masked, not persisted to disk, cleared with the session)
- `-new-pass`, `-ask-new-pass`, `-new-pass-env` on the command line

Some builds drop the session back to a login prompt after the change, where the old password is dead; the new one is used from that point on.

**Without one supplied**, the AP is reported as `Needs Password` and skipped immediately — not guessed at, and not left to burn the deadline. Setting a credential on a device only happens when explicitly asked for, which is also why `-ask-new-pass` is never offered unprompted the way `-ask-pass` is.

## Tests

Six new tests in `engine/ap/pwchange_test.go`, over a fake AP that forces a change and rejects a new password equal to the old one:

| Test | |
|---|---|
| `TestForcedPasswordChangeSetsTheSuppliedPassword` | one attempt, the right password, run continues to inventory |
| `TestForcedPasswordChangeWithoutOneIsReported` | sends nothing, status `Needs Password`, returns in well under the deadline |
| `TestReloginAfterChangeUsesTheNewPassword` | the post-change re-login path |
| `TestStatusLineIsNotMistakenForAPasswordPrompt` | `Password changed.` is not a prompt |
| `TestConfirmPromptBeatsTheNewPasswordPrompt` | seven prompt spellings resolve to the right class |

The first of these is the original reproduction, and it failed against the unfixed code before the fix existed. Full suite passes, `go vet` and `gofmt` clean.

Also bumps the version to `1.0.1`, since this wants a release.

## Not covered

The prompt wordings are my reconstruction of what a Ruckus AP prints, not a capture from real hardware — I have asked the reporter for the exact text their APs use. The end-anchored set covers the spellings I know of, but if theirs differs it will need one more pattern. Everything else here is exercised against the fake AP, same as the rest of the suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7hR9LhTCXJgP4vnHc6XhQ)_